### PR TITLE
Fix oauth qq

### DIFF
--- a/jpress-commons/src/main/java/io/jpress/commons/oauth2/OauthConnector.java
+++ b/jpress-commons/src/main/java/io/jpress/commons/oauth2/OauthConnector.java
@@ -33,6 +33,13 @@ public abstract class OauthConnector {
     private String name;
     private String redirectUri;
 
+    public OauthConnector(String name, String appkey, String appSecret, String redirectUri) {
+        this.clientId = appkey;
+        this.clientSecret = appSecret;
+        this.name = name;
+        this.redirectUri = redirectUri;
+    }
+
     public OauthConnector(String name, String appkey, String appSecret) {
         this.clientId = appkey;
         this.clientSecret = appSecret;

--- a/jpress-commons/src/main/java/io/jpress/commons/oauth2/connector/GithubConnector.java
+++ b/jpress-commons/src/main/java/io/jpress/commons/oauth2/connector/GithubConnector.java
@@ -51,7 +51,7 @@ public class GithubConnector extends OauthConnector {
 		user.setNickname(json.getString("login"));
 		user.setSource(getName());
 
-		return null;
+		return user;
 	}
 
 	protected String getAccessToken(String code) {
@@ -63,8 +63,8 @@ public class GithubConnector extends OauthConnector {
 
 		String url = urlBuilder.toString();
 
-		String httpString = httpGet(url);
-		JSONObject json = JSONObject.parseObject(httpString);
-		return json.getString("access_token");
-	}
+        String httpString = httpGet(url);
+        // access_token=b34db140be5ed745a0e8a07f9897d9ee1d8c432c&scope=user&token_type=bearer
+        return httpString.substring(httpString.indexOf("=") + 1, httpString.indexOf("&"));
+    }
 }

--- a/jpress-commons/src/main/java/io/jpress/commons/oauth2/connector/QQConnector.java
+++ b/jpress-commons/src/main/java/io/jpress/commons/oauth2/connector/QQConnector.java
@@ -23,92 +23,97 @@ import io.jpress.commons.oauth2.OauthUser;
 
 public class QQConnector extends OauthConnector {
 
-	public QQConnector(String name, String appkey, String appSecret) {
-		super(name, appkey, appSecret);
-	}
+    public QQConnector(String name, String appkey, String appSecret, String redirectUri) {
+        super(name, appkey, appSecret, redirectUri);
 
-	/**
-	 * http://wiki.connect.qq.com/%E4%BD%BF%E7%94%A8authorization_code
-	 */
-	@Override
-	public String createAuthorizeUrl(String state) {
+    }
 
-		StringBuilder sb = new StringBuilder("https://graph.qq.com/oauth2.0/authorize?");
-		sb.append("response_type=code");
-		sb.append("&client_id=" + getClientId());
-		sb.append("&redirect_uri=" + getRedirectUri());
-		sb.append("&state=" + state);
+    public QQConnector(String name, String appkey, String appSecret) {
+        super(name, appkey, appSecret);
+    }
 
-		return sb.toString();
-	}
+    /**
+     * http://wiki.connect.qq.com/%E4%BD%BF%E7%94%A8authorization_code
+     */
+    @Override
+    public String createAuthorizeUrl(String state) {
 
-	protected String getAccessToken(String code) {
+        StringBuilder sb = new StringBuilder("https://graph.qq.com/oauth2.0/authorize?");
+        sb.append("response_type=code");
+        sb.append("&client_id=" + getClientId());
+        sb.append("&redirect_uri=" + getRedirectUri());
+        sb.append("&state=" + state);
 
-		StringBuilder sb = new StringBuilder("https://graph.qq.com/oauth2.0/token?");
-		sb.append("grant_type=authorization_code");
-		sb.append("&code=" + code);
-		sb.append("&client_id=" + getClientId());
-		sb.append("&client_secret=" + getClientSecret());
-		sb.append("&redirect_uri=" + getRedirectUri());
+        return sb.toString();
+    }
 
-		String httpString = httpGet(sb.toString());
-		// access_token=2D6FE76*****24AB&expires_in=7776000&refresh_token=7CD56****218
+    protected String getAccessToken(String code) {
 
-		if (StrUtil.isBlank(httpString)) {
-			return null;
-		}
+        StringBuilder sb = new StringBuilder("https://graph.qq.com/oauth2.0/token?");
+        sb.append("grant_type=authorization_code");
+        sb.append("&code=" + code);
+        sb.append("&client_id=" + getClientId());
+        sb.append("&client_secret=" + getClientSecret());
+        sb.append("&redirect_uri=" + getRedirectUri());
 
-		return httpString.substring(httpString.indexOf("=") + 1, httpString.indexOf("&"));
-	}
+        String httpString = httpGet(sb.toString());
+        // access_token=2D6FE76*****24AB&expires_in=7776000&refresh_token=7CD56****218
 
-	protected String getOpenId(String accessToken, String code) {
+        if (StrUtil.isBlank(httpString)) {
+            return null;
+        }
 
-		StringBuilder sb = new StringBuilder("https://graph.qq.com/oauth2.0/me?");
-		sb.append("access_token=" + accessToken);
+        return httpString.substring(httpString.indexOf("=") + 1, httpString.indexOf("&"));
+    }
 
-		String httpString = httpGet(sb.toString());
-		// callback(
-		// {"client_id":"10***65","openid":"F8D32108D*****D"}
-		// );
+    protected String getOpenId(String accessToken, String code) {
 
-		if (StrUtil.isBlank(httpString)) {
-			return null;
-		}
-		return httpString.substring(httpString.lastIndexOf(":") + 2, httpString.lastIndexOf("\""));
-	}
+        StringBuilder sb = new StringBuilder("https://graph.qq.com/oauth2.0/me?");
+        sb.append("access_token=" + accessToken);
 
-	@Override
-	protected OauthUser getOauthUser(String code) {
-		String accessToken = getAccessToken(code);
-		if (StrUtil.isBlank(accessToken)) {
-			return null;
-		}
-		String openId = getOpenId(accessToken, code);
-		if (StrUtil.isBlank(openId)) {
-			return null;
-		}
+        String httpString = httpGet(sb.toString());
+        // callback(
+        // {"client_id":"10***65","openid":"F8D32108D*****D"}
+        // );
 
-		StringBuilder sb = new StringBuilder("https://graph.qq.com/user/get_user_info?");
-		sb.append("access_token=" + accessToken);
-		sb.append("&oauth_consumer_key=" + getClientId());
-		sb.append("&openid=" + openId);
-		sb.append("&format=format");
+        if (StrUtil.isBlank(httpString)) {
+            return null;
+        }
+        return httpString.substring(httpString.lastIndexOf(":") + 2, httpString.lastIndexOf("\""));
+    }
 
-		String httpString = httpGet(sb.toString());
-		
-		if (StrUtil.isBlank(httpString)) {
-			return null;
-		}
+    @Override
+    protected OauthUser getOauthUser(String code) {
+        String accessToken = getAccessToken(code);
+        if (StrUtil.isBlank(accessToken)) {
+            return null;
+        }
+        String openId = getOpenId(accessToken, code);
+        if (StrUtil.isBlank(openId)) {
+            return null;
+        }
 
-		JSONObject json = JSON.parseObject(httpString);
-		OauthUser user = new OauthUser();
+        StringBuilder sb = new StringBuilder("https://graph.qq.com/user/get_user_info?");
+        sb.append("access_token=" + accessToken);
+        sb.append("&oauth_consumer_key=" + getClientId());
+        sb.append("&openid=" + openId);
+        sb.append("&format=format");
 
-		user.setAvatar(json.getString("figureurl_2"));
-		user.setNickname(json.getString("nickname"));
-		user.setOpenId(openId);
-		user.setSource(getName());
+        String httpString = httpGet(sb.toString());
 
-		return user;
-	}
+        if (StrUtil.isBlank(httpString)) {
+            return null;
+        }
+
+        JSONObject json = JSON.parseObject(httpString);
+        OauthUser user = new OauthUser();
+
+        user.setAvatar(json.getString("figureurl_2"));
+        user.setNickname(json.getString("nickname"));
+        user.setOpenId(openId);
+        user.setSource(getName());
+
+        return user;
+    }
 
 }

--- a/jpress-web/src/main/java/io/jpress/web/front/OauthController.java
+++ b/jpress-web/src/main/java/io/jpress/web/front/OauthController.java
@@ -85,12 +85,12 @@ public class OauthController extends Oauth2Controller {
                 return;
         }
 
-        if (dbUser == null){
+        if (dbUser != null) {
             dbUser = UserInterceptor.getThreadLocalUser();
-            if (dbUser != null){
+            if (dbUser != null) {
                 dbUser.setAvatar(ouser.getAvatar());
                 dbUser.setNickname(ouser.getNickname());
-                openidService.saveOrUpdate(dbUser.getId(),ouser.getSource(),ouser.getOpenId());
+                openidService.saveOrUpdate(dbUser.getId(), ouser.getSource(), ouser.getOpenId());
                 userService.update(dbUser);
             }
         }
@@ -104,12 +104,12 @@ public class OauthController extends Oauth2Controller {
             dbUser.setGender(ouser.getGender());
             dbUser.setSalt(HashKit.generateSaltForSha256());
             Object id = userService.save(dbUser);
-            openidService.saveOrUpdate(id,ouser.getSource(),ouser.getOpenId());
+            openidService.saveOrUpdate(id, ouser.getSource(), ouser.getOpenId());
 
         }
 
         CookieUtil.put(this, JPressConsts.COOKIE_UID, dbUser.getId());
-        String gotoUrl = JPressOptions.get("login_goto_url","/ucenter");
+        String gotoUrl = JPressOptions.get("login_goto_url", "/ucenter");
         redirect(gotoUrl);
     }
 
@@ -201,10 +201,13 @@ public class OauthController extends Oauth2Controller {
         if (enable == false) {
             return null;
         }
+        String para = getPara();
+        String requestUrl = getRequest().getRequestURL().toString();
+        String callBackUrl = requestUrl.replace("/" + para, "/callback/" + para);
 
         String appkey = JPressOptions.get("login_qq_appkey");
         String appsecret = JPressOptions.get("login_qq_appsecret");
-        return new QQConnector("qq", appkey, appsecret);
+        return new QQConnector("qq", appkey, appsecret, callBackUrl);
     }
 
     private OauthConnector createWechatConnector() {
@@ -212,6 +215,7 @@ public class OauthController extends Oauth2Controller {
         if (enable == false) {
             return null;
         }
+
 
         String appkey = JPressOptions.get("login_wechat_appkey");
         String appsecret = JPressOptions.get("login_wechat_appsecret");


### PR DESCRIPTION
修复QQ登录获取AccessToken参数错误的情况,
按照qq开放平台的解释,在获取AccessToken时`redirect_uri`参数为必填
![image](https://user-images.githubusercontent.com/15245021/72209568-de9c5380-34ea-11ea-82bf-525f2e573cfc.png)

具体可参照下文档
https://wiki.connect.qq.com/%E4%BD%BF%E7%94%A8authorization_code%E8%8E%B7%E5%8F%96access_token